### PR TITLE
Display Board Information on Command Start

### DIFF
--- a/src/AppBundle/Command/CardFilterCommand.php
+++ b/src/AppBundle/Command/CardFilterCommand.php
@@ -83,10 +83,25 @@ class CardFilterCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $output->writeln('Loading board from API... ');
+        $board = $this->getTrelloClient()->getBoard($this->getBoardId());
         $output->writeln('Loading cards from API...');
         $this->boardCards = $this->getTrelloClient()->getBoardCards($this->getBoardId());
         $output->writeln('Loading lists from API...');
         $this->boardLists = $this->getTrelloClient()->getBoardLists($this->getBoardId());
+
+        // Print board information
+        $output->writeln(PHP_EOL.'+----------------------------------------------------------------+');
+        $table = new Table($output);
+        $table->setStyle('compact');
+        $table->setColumnWidths([15, 50]);
+        $table->setRows([
+            ['Board Name:', $board->getName()],
+            ['Board URL:', $board->getShortUrl()],
+            ['Last Activity:', $board->getDateLastActivity()->format('Y-m-d H:i:s')]
+        ]);
+        $table->render();
+        $output->writeln('+----------------------------------------------------------------+'.PHP_EOL);
 
         $continue = true;
         while ($continue){

--- a/src/AppBundle/Helper/TrelloClient/Model/Board.php
+++ b/src/AppBundle/Helper/TrelloClient/Model/Board.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace AppBundle\Helper\TrelloClient\Model;
+
+
+use JMS\Serializer\Annotation as Serializer;
+
+class Board
+{
+    /**
+     * The ID of the board
+     *
+     * @var string
+     * @Serializer\Type("string")
+     */
+    private $id;
+
+    /**
+     * The name of the board
+     *
+     * @var string
+     * @Serializer\Type("string")
+     */
+    private $name;
+
+    /**
+     * URL for the board using only its shortMongoID
+     *
+     * @var string
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("shortUrl")
+     */
+    private $shortUrl;
+
+    /**
+     *
+     * @var \DateTime
+     * @Serializer\Type("DateTime<'Y-m-d\TH:i:s.uT'>")
+     * @Serializer\SerializedName("dateLastActivity")
+     */
+    private $dateLastActivity;
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getShortUrl(): string
+    {
+        return $this->shortUrl;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateLastActivity(): \DateTime
+    {
+        return $this->dateLastActivity;
+    }
+}

--- a/src/AppBundle/Helper/TrelloClient/TrelloClient.php
+++ b/src/AppBundle/Helper/TrelloClient/TrelloClient.php
@@ -3,7 +3,9 @@
 namespace AppBundle\Helper\TrelloClient;
 
 
+use AppBundle\Helper\TrelloClient\Model\Board;
 use AppBundle\Helper\TrelloClient\Model\BoardList;
+use AppBundle\Helper\TrelloClient\Model\Card;
 use AppBundle\Helper\TrelloClient\Model\Member;
 use Doctrine\Common\Collections\ArrayCollection;
 use GuzzleHttp\Client;
@@ -58,6 +60,24 @@ class TrelloClient
             RequestOptions::TIMEOUT => '30',
             RequestOptions::HTTP_ERRORS => true
         ]);
+    }
+
+    /**
+     * @param $boardId
+     *
+     * @return Board
+     */
+    public function getBoard($boardId)
+    {
+        $queryParameters = [
+            'fields' => 'id,name,shortUrl,dateLastActivity',
+        ];
+        return $this->makeRequest(
+            'boards/'.$boardId,
+            'GET',
+            'AppBundle\Helper\TrelloClient\Model\Board',
+            $queryParameters
+        );
     }
 
     /**


### PR DESCRIPTION
This PR implements the features in #1 

The output looks as follows:
```
$ bin/console filter:cards --board_id=XXXXXX
Loading board from API...
Loading cards from API...
Loading lists from API...

+----------------------------------------------------------------+
 Board Name:     AF Skunkworks Ideas (Brad)
 Board URL:      https://trello.com/b/XXXXXX
 Last Activity:  2019-10-07 15:57:22
+----------------------------------------------------------------+

Total Cards: 7 Filtered Cards: 7
Options:
  [0] Add Filter
  [1] Remove Filter
  [2] Print Cards
  [3] Refresh Cards
  [4] Exit
 > 0
```